### PR TITLE
Added support for pipeline deployment to docker

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -4,7 +4,7 @@ variables:
   - &platforms "linux/amd64,linux/arm64,linux/arm/v7"
 
 pipeline:
-  - name: Test
+  - name: Test and Build
     image: *node_image
     commands:
       - apk add --no-cache curl
@@ -14,7 +14,8 @@ pipeline:
       - curl -s localhost:3000
     ports:
       - 3000:3000
-  - name: Deploy
+
+  - name: Deploy to Docker Hub
     image: *buildx_image
     secrets: [docker_username, docker_password]
     settings:
@@ -22,4 +23,16 @@ pipeline:
       dockerfile: Dockerfile
       platforms: *platforms
       tag: latest
+
+  - name: Deploy Tagged Version
+    image: *buildx_image
+    secrets: [docker_username, docker_password]
+    settings:
+      repo: insidiousfiddler/yasifystools
+      dockerfile: Dockerfile
+      platforms: *platforms
+      tag: [latest, "${CI_COMMIT_TAG}"]
+    when:
+      event: tag
+
 branches: [main, dev-*, feature-*]

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,6 +1,11 @@
+variables:
+  - &node_image "node:14-alpine"
+  - &buildx_image "woodpeckerci/plugin-docker-buildx"
+  - &platforms "linux/amd64,linux/arm64,linux/arm/v7"
+
 pipeline:
   - name: Test
-    image: node:14-alpine
+    image: *node_image
     commands:
       - apk add --no-cache curl
       - npm install
@@ -9,4 +14,12 @@ pipeline:
       - curl -s localhost:3000
     ports:
       - 3000:3000
+  - name: Deploy
+    image: *buildx_image
+    secrets: [docker_username, docker_password]
+    settings:
+      repo: insidiousfiddler/yasifystools
+      dockerfile: Dockerfile
+      platforms: *platforms
+      tag: latest
 branches: [main, dev-*, feature-*]


### PR DESCRIPTION
Refactor pipeline job names and add a job for tagging images

Summary:

Rename Test job to Test and Build, and add a new Deploy Tagged Version job for tagged images.

Details:

This commit updates the .woodpecker.yml file to rename the pipeline job Test to Test and Build for clarity. It also adds a new job called Deploy Tagged Version for tagging images. The newly created job uses the *buildx_image image and the Dockerfile for building images. The job's settings also include platforms, repo, and tags. The branching logic is unaltered.