### PR TITLE
Refactor metadata image URLs in 404 and player views

### DIFF
--- a/views/404.ejs
+++ b/views/404.ejs
@@ -9,13 +9,13 @@
   <meta property="og:description" content="Yasifys is a free online tool for downloading videos from popular video sharing websites, including YouTube, TikTok, Facebook, and more.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://www.yasifys.tk/about">
-  <meta property="og:image" content="https://www.yasifys.tk/card/Card.png">
+  <meta property="og:image" content="https://www.yasifys.tk/assets/img/meta/Card.png">
   <meta property="og:image:alt" content="Yasifys logo">
   <meta property="og:site_name" content="Yasifys">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="404 - Page Not Found">
   <meta name="twitter:description" content="Yasifys is a free online tool for downloading videos from popular video sharing websites, including YouTube, TikTok, Facebook, and more.">
-  <meta name="twitter:image" content="https://www.yasifys.tk/card/Card.png">
+  <meta name="twitter:image" content="https://www.yasifys.tk/assets/img/meta/Card.png">
   <meta name="twitter:image:alt" content="Yasifys logo">
 
     <link rel="icon" type="image/png" href="/favicon/favicon32x32.png">

--- a/views/player.ejs
+++ b/views/player.ejs
@@ -9,13 +9,13 @@
   <meta property="og:description" content="Yasifys is a free online tool for downloading videos from popular video sharing websites, including YouTube, TikTok, Facebook, and more.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://www.yasifys.tk/player">
-  <meta property="og:image" content="https://www.yasifys.tk/card/Card.png">
+  <meta property="og:image" content="https://www.yasifys.tk/assets/img/meta/Card.png">
   <meta property="og:image:alt" content="Yasifys logo">
   <meta property="og:site_name" content="Yasifys">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="About - Yasifys YouTube Downloader">
   <meta name="twitter:description" content="Yasifys is a free online tool for downloading videos from popular video sharing websites, including YouTube, TikTok, Facebook, and more.">
-  <meta name="twitter:image" content="https://www.yasifys.tk/card/Card.png">
+  <meta name="twitter:image" content="https://www.yasifys.tk/assets/img/meta/Card.png">
   <meta name="twitter:image:alt" content="Yasifys logo">
 
     <link rel="icon" type="image/png" href="/favicon/favicon32x32.png">


### PR DESCRIPTION
Replace the og:image and twitter:image URLs with the new location of the Card.png image in the meta tags in the 404 and player views to reflect the website's assets directory.