### PR TITLE
Update .gitignore and fix CI_COMMIT_TAG issue in .woodpecker.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# PhpStorm
+.idea/

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -33,7 +33,7 @@ pipeline:
       repo: insidiousfiddler/yasifystools
       dockerfile: Dockerfile
       platforms: *platforms
-      tag: [latest, "${CI_COMMIT_TAG}"]
+      tag: [latest, "${CI_COMMIT_TAG:1}"]
     when:
       event: tag
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -33,7 +33,7 @@ pipeline:
       repo: insidiousfiddler/yasifystools
       dockerfile: Dockerfile
       platforms: *platforms
-      tag: [latest, "${CI_COMMIT_TAG:1}"]
+      tag: [latest, "${CI_COMMIT_TAG#v}"]
     when:
       event: tag
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yasifys-tools",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "yasifys-tools",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yasifys-tools",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "description": "A website with tools to download videos from popular social media platforms.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
This pull request contains two commits that update the project's .gitignore file and fix an issue with the CI_COMMIT_TAG variable in the .woodpecker.yml configuration file.

In the first commit, the .idea/ directory is added to the .gitignore file to ensure that the PhpStorm IDE files are excluded from version control.

The second commit fixes a bug where the CI_COMMIT_TAG variable included a 'v' prefix, causing issues with the Woodpecker CI/CD pipeline. The fix involves removing the prefix from the variable.