### PR TITLE
Update badge URLs and improve logging for disconnections

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status][status-badge]][status-url]
 [![MIT License][license-badge]][license-url]
 [![Docker Pulls][docker-pulls-badge]][docker-pulls-url]
-[![Quality Gate Status](https://sonar.vahngomes.dev/api/project_badges/measure?project=yasifys-tools&metric=alert_status)](https://sonar.vahngomes.dev/dashboard?id=yasifys-tools)
+[![Quality Gate Status][sonar-badge]][sonar-url]
 
 YouTube Downloader is a versatile tool that allows users to easily download YouTube videos in various formats. With this open-source project, you can quickly extract and save videos from YouTube by providing the video URL. The downloader supports popular video formats like MP4 and provides a simple and intuitive user interface.
 
@@ -61,9 +61,11 @@ docker pull insidiousfiddler/yasifystools && docker run -it --rm -p 0:3000 insid
 [forks-url]: https://github.com/tyler-Github/YasifysTools/network
 [issues-shield]: https://img.shields.io/github/issues/tyler-Github/YasifysTools.svg
 [issues-url]: https://github.com/tyler-Github/YasifysTools/issues
-[status-badge]: https://woodpecker.vahngomes.dev/api/badges/tyler-Github/YasifysTools/status.svg
-[status-url]: https://woodpecker.vahngomes.dev/tyler-Github/YasifysTools
+[status-badge]: https://woodpecker.vahngomes.dev/api/badges/28/status.svg
+[status-url]: https://woodpecker.vahngomes.dev/28
 [docker-pulls-url]: https://hub.docker.com/r/insidiousfiddler/yasifystools
 [docker-pulls-badge]: https://img.shields.io/docker/pulls/insidiousfiddler/yasifystools.svg
 [license-url]: LICENSE
 [license-badge]: https://img.shields.io/github/license/tyler-Github/YasifysTools.svg
+[sonar-url]: https://sonar.vahngomes.dev/dashboard?id=yasifys-tools
+[sonar-badge]: https://sonar.vahngomes.dev/api/project_badges/measure?project=yasifys-tools&metric=alert_status

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -293,6 +293,11 @@
         console.log("Client connected to server.");
       });
 
+      // Loss of connection to server
+      socket.on("disconnect", function () {
+        console.log("Client disconnected from server.");
+      });
+
       // Download video
       function downloadVideo() {
         const url = document.getElementById("video-url").value;
@@ -326,7 +331,6 @@
       // Listen for download progress
       socket.on("download-progress", function (data) {
         const progress = data.progress;
-        console.log("Downloading: " + progress + "%");
         const progressBar = document.getElementById("progress-bar");
         progressBar.value = progress;
         progressBar.innerHTML = progress + "%";


### PR DESCRIPTION
This pull request addresses two issues and introduces improvements to the application:

1. Fixed URLs in the README.md file for the SonarQube quality gate badge and the Woodpecker build status badge. The URLs now point to the correct project.
2. Removed an unnecessary console.log statement in the index.ejs template, reducing noise in the console output.
3. Added a socket event listener for "disconnect" in index.ejs to log when a client is disconnected from the server.

These changes ensure accurate badge URLs for project integration and improve the clarity of the console output by removing unnecessary logs.