### PR TITLE
chore(package.json): Bump version to 1.5.0 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yasifys-tools",
-  "version": "1.4.6",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "yasifys-tools",
-      "version": "1.4.6",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yasifys-tools",
-  "version": "1.4.6",
+  "version": "1.5.0",
   "description": "A website with tools to download videos from popular social media platforms.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
This PR bumps the version in the package.json file to 1.5.0 in preparation for the release.