### PR TITLE
Update Node.js parent image to 18-alpine for improved compatibility and security

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,5 +1,5 @@
 variables:
-  - &node_image "node:14-alpine"
+  - &node_image "node:18-alpine"
   - &buildx_image "woodpeckerci/plugin-docker-buildx"
   - &platforms "linux/amd64,linux/arm64,linux/arm/v7"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as a parent image
-FROM node:16.20.1-alpine
+FROM node:18-alpine
 
 # Set the working directory to /app
 WORKDIR /app


### PR DESCRIPTION
This pull request updates the Node.js parent image version specified in the Dockerfile to 18-alpine. By doing so, it ensures better compatibility with the latest dependencies and enhances the container's overall security.